### PR TITLE
fix crash when adjust partition number

### DIFF
--- a/producer/TalosProducer.go
+++ b/producer/TalosProducer.go
@@ -540,6 +540,8 @@ func (p *TalosProducer) DescribeTopicInfo() (*topic.TopicTalosResourceName, int3
 }
 
 func (c *TalosProducer) ProducerMonitorTask() {
+	c.producerLock.Lock()
+	defer c.producerLock.Unlock()
 	metrics := make([]*utils.FalconMetric, 0)
 	for _, p := range c.partitionSenderMap {
 		metrics = append(metrics, p.NewFalconMetrics()...)


### PR DESCRIPTION
当调整分区时，adjustPartitionSender会上锁对partitionSenderMap进行写。如果此时正好ProducerMonitorTask运行，会循环partitionSenderMap创建metrics信息，此时便会产生fatal error: concurrent map iteration and map write错误，程序直接崩溃。本次提交主要是增加上锁，避免这个错误。